### PR TITLE
Support for horizontal barchart

### DIFF
--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -190,19 +190,22 @@ def show_bar_values(fmt: str = "{}", alignment: str = "vertical") -> None:
     axis_to_data = ax.transAxes + ax.transData.inverted()
 
     for rect in ax.patches:
-        # compute position
         if alignment == "vertical":
             height = rect.get_height()
             ypos_ax = data_to_axis.transform([1.0, height])
             ypos = axis_to_data.transform(ypos_ax - 0.1)[1]
             xpos = rect.get_x() + rect.get_width() / 2
             s = fmt.format(height)
+            ha = "center"
+            va = "bottom"
         elif alignment == "horizontal":
             width = rect.get_width()
             xpos_ax = data_to_axis.transform([1.0, width])
-            xpos = axis_to_data.transform(xpos_ax - 0.3)[1]
-            ypos = rect.get_y() + rect.get_height() / 2 - 0.1
+            xpos = axis_to_data.transform(xpos_ax - 0.1)[1]
+            ypos = rect.get_y() + rect.get_height() / 2
             s = fmt.format(width)
+            ha = "right"
+            va = "center"
 
         ax.text(
             xpos,
@@ -210,7 +213,7 @@ def show_bar_values(fmt: str = "{}", alignment: str = "vertical") -> None:
             s,
             size=14,
             weight="bold",
-            ha="center",
-            va="bottom",
+            ha=ha,
+            va=va,
             color="white",
         )

--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -175,11 +175,11 @@ def show_bar_values(fmt: str = "{}", alignment: str = "vertical") -> None:
     if alignment == "vertical":
         plt.tick_params(
             axis="y", which="both", left=False, right=False, labelleft=False
-    )
+        )
     elif alignment == "horizontal":
         plt.tick_params(
             axis="x", which="both", bottom=False, top=False, labelbottom=False
-    )
+        )
 
     plt.grid(False)
 

--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -174,10 +174,12 @@ def show_bar_values(fmt: str = "{}", alignment: str = "vertical") -> None:
     # turn off ticks and grid
     if alignment == "vertical":
         plt.tick_params(
-            axis="y", which="both", left=False, right=False, labelleft=False)
+            axis="y", which="both", left=False, right=False, labelleft=False
+    )
     elif alignment == "horizontal":
         plt.tick_params(
-            axis="x", which="both", bottom=False, top=False, labelbottom=False)
+            axis="x", which="both", bottom=False, top=False, labelbottom=False
+    )
 
     plt.grid(False)
 

--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -165,6 +165,12 @@ def ylabel_top(string: str) -> None:
 def show_bar_values(fmt: str = "{}", alignment: str = "vertical") -> None:
     ax = plt.gca()
 
+    # check alignment
+    if alignment not in ["vertical", "horizontal"]:
+        msg = "Unknown alignment {}".format(alignment)
+        msg += " (should be horizontal or vertical)"
+        raise ValueError(msg)
+
     # turn off ticks and grid
     if alignment == "vertical":
         plt.tick_params(

--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -165,19 +165,18 @@ def ylabel_top(string: str) -> None:
 def show_bar_values(fmt: str = "{}", alignment: str = "vertical") -> None:
     ax = plt.gca()
 
-    # turn off y-ticks and y-grid
+    # turn off ticks and grid
     if alignment == "vertical":
-        plt.tick_params(axis="y", which="both", left=False, right=False, labelleft=False)
+        plt.tick_params(
+            axis="y", which="both", left=False, right=False, labelleft=False)
     elif alignment == "horizontal":
-        plt.tick_params(axis="x", which="both", bottom=False, top=False, labelbottom=False)
+        plt.tick_params(
+            axis="x", which="both", bottom=False, top=False, labelbottom=False)
 
     plt.grid(False)
 
     # remove margins
-    if alignment == "vertical":
-        plt.margins(x=0)
-    elif alignment == "horizontal":
-        plt.margins(y=0)
+    plt.margins(x=0, y=0)
 
     data_to_axis = ax.transData + ax.transAxes.inverted()
     axis_to_data = ax.transAxes + ax.transData.inverted()

--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -162,27 +162,45 @@ def ylabel_top(string: str) -> None:
     yl.set_rotation(0)
 
 
-def show_bar_values(fmt: str = "{}") -> None:
+def show_bar_values(fmt: str = "{}", alignment: str = "vertical") -> None:
     ax = plt.gca()
 
     # turn off y-ticks and y-grid
-    plt.tick_params(axis="y", which="both", left=False, right=False, labelleft=False)
+    if alignment == "vertical":
+        plt.tick_params(axis="y", which="both", left=False, right=False, labelleft=False)
+    elif alignment == "horizontal":
+        plt.tick_params(axis="x", which="both", bottom=False, top=False, labelbottom=False)
+
     plt.grid(False)
 
     # remove margins
-    plt.margins(x=0)
+    if alignment == "vertical":
+        plt.margins(x=0)
+    elif alignment == "horizontal":
+        plt.margins(y=0)
 
     data_to_axis = ax.transData + ax.transAxes.inverted()
     axis_to_data = ax.transAxes + ax.transData.inverted()
 
     for rect in ax.patches:
-        height = rect.get_height()
-        ypos_ax = data_to_axis.transform([1.0, height])
-        ypos = axis_to_data.transform(ypos_ax - 0.1)[1]
+        # compute position
+        if alignment == "vertical":
+            height = rect.get_height()
+            ypos_ax = data_to_axis.transform([1.0, height])
+            ypos = axis_to_data.transform(ypos_ax - 0.1)[1]
+            xpos = rect.get_x() + rect.get_width() / 2
+            s = fmt.format(height)
+        elif alignment == "horizontal":
+            width = rect.get_width()
+            xpos_ax = data_to_axis.transform([1.0, width])
+            xpos = axis_to_data.transform(xpos_ax - 0.3)[1]
+            ypos = rect.get_y() + rect.get_height() / 2 - 0.1
+            s = fmt.format(width)
+
         ax.text(
-            rect.get_x() + rect.get_width() / 2,
+            xpos,
             ypos,
-            fmt.format(height),
+            s,
             size=14,
             weight="bold",
             ha="center",

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -17,8 +17,7 @@ def test_bar():
 
 
 def test_bar_horizontal():
-    """Checks that a bar chart can be created with horizontal alignment
-    """
+    """Checks that a bar chart can be created with horizontal alignment"""
     with plt.style.context(matplotx.styles.dufte_bar):
         labels = ["label 1", "label 2"]
         vals = [2.1, 6.3]
@@ -31,8 +30,7 @@ def test_bar_horizontal():
 
 
 def test_wrong_alignment():
-    """Checks that an error is raised when alignment has an invalid value
-    """
+    """Checks that an error is raised when alignment has an invalid value"""
     with pytest.raises(ValueError, match="Unknown alignment"):
         matplotx.show_bar_values(alignment="coucou")
 

--- a/tests/test_bar.py
+++ b/tests/test_bar.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import pytest
 
 import matplotx
 
@@ -13,6 +14,27 @@ def test_bar():
         matplotx.show_bar_values("{:.2f}")
         plt.title("some title")
         plt.close()
+
+
+def test_bar_horizontal():
+    """Checks that a bar chart can be created with horizontal alignment
+    """
+    with plt.style.context(matplotx.styles.dufte_bar):
+        labels = ["label 1", "label 2"]
+        vals = [2.1, 6.3]
+        ypos = range(len(vals))
+        plt.barh(ypos, vals)
+        plt.xticks(ypos, labels)
+        matplotx.show_bar_values("{:.2f}", alignment="horizontal")
+        plt.title("some title")
+        plt.close()
+
+
+def test_wrong_alignment():
+    """Checks that an error is raised when alignment has an invalid value
+    """
+    with pytest.raises(ValueError, match="Unknown alignment"):
+        matplotx.show_bar_values(alignment="coucou")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR solves #30 by adding an `alignment` argument to `show_bar_values` defaulting to "vertical".

I couldn't think of a robust way of determining the alignment automatically.
Checking if the width of the bar is greater or lower than its height seemed a bit dodgy in some cases... I don't know. What do you think @nschloe ?

Usage (adapted from README demo):
```python
import matplotlib.pyplot as plt
import matplotx

labels = ["Australia", "Brazil", "China", "Germany", "Mexico", "United\nStates"]
vals = [21.65, 24.5, 6.95, 8.40, 21.00, 8.55]
ypos = range(len(vals))


with plt.style.context(matplotx.styles.dufte_bar):
    plt.barh(ypos, vals)
    plt.yticks(ypos, labels)
    matplotx.show_bar_values("{:.2f}", alignment="horizontal")
    plt.title("average temperature [°C]")
    plt.tight_layout()
    plt.show()
```

Produces:
![Figure_1](https://user-images.githubusercontent.com/40028739/152686806-2b76af65-2e33-4b4a-b2d7-e018ce2c3387.png)

