### PR TITLE
Remove print statement in `line_labels()`

### DIFF
--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -55,7 +55,6 @@ def line_labels(
         ax_height_inches = ax_height * fig_height_inches
         ylim = ax.get_ylim()
         if logy:
-            print(ylim)
             ax_height_ylim = math.log10(ylim[1]) - math.log10(ylim[0])
         else:
             ax_height_ylim = ylim[1] - ylim[0]


### PR DESCRIPTION
This PR just removes a print statement in the line_labels function, which was a bit annoying 😄 