### PR TITLE
Support for subplots

### DIFF
--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -49,7 +49,7 @@ def line_labels(
         # into axes units.
         fig = plt.gcf()
         fig_height_inches = fig.get_size_inches()[1]
-        ax = plt.gca()
+        ax = plt.gca()            # This is redudent because line 43? Not 100% sure so kept it in. 
         ax_pos = ax.get_position()
         ax_height = ax_pos.y1 - ax_pos.y0
         ax_height_inches = ax_height * fig_height_inches
@@ -112,7 +112,7 @@ def line_labels(
     axis_to_data = ax.transAxes + ax.transData.inverted()
     xpos = axis_to_data.transform([1.03, 1.0])[0]
     for label, ypos, color in zip(labels, targets, colors):
-        plt.text(
+        ax.set_text(
             xpos, ypos, label, verticalalignment="center", color=color, **text_kwargs
         )
 

--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -117,12 +117,12 @@ def line_labels(
         )
 
 
-def ylabel_top(string: str) -> None:
+def ylabel_top(string: str, ax=None) -> None:
     # Rotate the ylabel (such that you can read it comfortably) and place it above the
     # top ytick. This requires some logic, so it cannot be incorporated in `style`.
     # See <https://stackoverflow.com/a/27919217/353337> on how to get the axes
     # coordinates of the top ytick.
-    ax = plt.gca()
+    ax = ax or plt.gca()
 
     yticks_pos = ax.get_yticks()
     coords = np.column_stack([np.zeros_like(yticks_pos), yticks_pos])
@@ -155,7 +155,7 @@ def ylabel_top(string: str) -> None:
         bbox = ax.get_window_extent().transformed(plt.gcf().dpi_scale_trans.inverted())
         pos_x = -dist_in / bbox.width
 
-    yl = plt.ylabel(string, horizontalalignment="right", multialignment="right")
+    yl = ax.set_ylabel(string, horizontalalignment="right", multialignment="right")
     # place the label 10% above the top tick
     ax.yaxis.set_label_coords(pos_x, pos_y)
     yl.set_rotation(0)


### PR DESCRIPTION
Related to the issue I opened. It seems that small changes already go quite a long way towards support for subplots.  This does not yet work for the style. 

For the original code, everything was correctly calculated with the axes in mind, but then it was applied to `plt` instead of `ax`, even if an `ax` parameter was supplied for `line_labels`, it was still applied to `plt`. 

The code changes should have no effect when there are no subplots. When there are subplots, the code now offers better support. 


```
import matplotlib.pyplot as plt
import matplotx
import numpy as np

# create data
rng = np.random.default_rng(0)
offsets = [1.0, 1.50, 1.60]
labels = ["no balancing", "CRV-27", "CRV-27*"]
names = ["Plot left", "Plot right"]
x0 = np.linspace(0.0, 3.0, 100)
y = [offset * x0 / (x0 + 1) + 0.1 * rng.random(len(x0)) for offset in offsets]

fig, axes = plt.subplots(2,1)                                           

for ax, name in zip(axes, names):                                                         
    with plt.style.context(matplotx.styles.dufte):
        for yy, label in zip(y, labels):
            ax.plot(x0, yy, label=label)                                
        ax.set_xlabel("distance [m]")                                   
    matplotx.ylabel_top(name)    
    matplotx.line_labels(ax=ax)
```

**Original code**


![image](https://user-images.githubusercontent.com/101918056/173716228-491feee7-48f1-415e-9f40-26d2661769e0.png)

**New code**

![image](https://user-images.githubusercontent.com/101918056/173716403-ba1cf0f2-08ce-45d1-8b71-b0a04a2f6a44.png)
