### PR TITLE
plt rcParams instead of mpl. Label color optional

### DIFF
--- a/src/matplotx/_labels.py
+++ b/src/matplotx/_labels.py
@@ -41,6 +41,7 @@ def line_labels(
     ax: plt.Axes | None = None,
     min_label_distance: float | str = "auto",
     alpha: float = 1.0,
+    use_line_colors: bool = True,
     **text_kwargs,
 ):
     if ax is None:
@@ -61,7 +62,8 @@ def line_labels(
         else:
             ax_height_ylim = ylim[1] - ylim[0]
         # 1 pt = 1/72 in
-        fontsize = mpl.rcParams["font.size"]
+        # use plt rcParams for use with per plot params (e.g., plt.rc_context)
+        fontsize = plt.rcParams["font.size"]
         assert fontsize is not None
         min_label_distance_inches = fontsize / 72 * alpha
         min_label_distance = (
@@ -104,7 +106,11 @@ def line_labels(
         targets = [10**t for t in targets]
 
     labels = [line.get_label() for line in lines]
-    colors = [line.get_color() for line in lines]
+    # default to black labels if not using line colors as font color
+    if use_line_colors:
+        colors = [line.get_color() for line in lines]
+    else:
+        colors = ["black" for line in lines]
 
     # Leave the labels some space to breathe. If they are too close to the
     # lines, they can get visually merged.


### PR DESCRIPTION
This fork makes two changes to the line_labels() function in _lines.py file:
1. Adds function parameter use_line_colors: bool = True to specify if the color of the text series labels should match the line colors. If False, the text will be black.
2. Get font size from plt.rcParams instead of mpl.rcParams. This allows the font size to correspond to the axes fontsize, which may differ from the global mpl params. This is particularly useful when using the plt.rc_context rcParams context manager.